### PR TITLE
fix/cant-max

### DIFF
--- a/PalletsApiCore/.config/dotnet-tools.json
+++ b/PalletsApiCore/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "9.0.9",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/PalletsApiCore/Program.cs
+++ b/PalletsApiCore/Program.cs
@@ -79,6 +79,8 @@ app.MapGet("api/pallets/productos", async (string? numero, ESCORIALContext conte
     {
         var producto = await context.producto
             .FirstOrDefaultAsync(producto => producto.id == item.producto_id);
+        var udProducto = await context.ud_producto
+            .FirstOrDefaultAsync(ud_producto => ud_producto.id == producto!.boextension_id);
         var etiqueta = await context.vp_etiquetas
             .FirstOrDefaultAsync(vp_etiquetas => vp_etiquetas.numero == int.Parse(item.serie) && vp_etiquetas.producto_id == producto!.id);
         if (producto is not null)
@@ -89,7 +91,7 @@ app.MapGet("api/pallets/productos", async (string? numero, ESCORIALContext conte
                 productCode = producto.codigo,
                 description = producto.descripcion,
                 type = etiqueta?.tipo,
-                maxCantByPallet = 1,
+                maxCantByPallet = udProducto.cant_x_pallet,
                 isAvailable = true
             });
     }

--- a/PalletsApiCore/Program.cs
+++ b/PalletsApiCore/Program.cs
@@ -147,68 +147,6 @@ app.MapGet("api/productos", async (string? tipo, int? numero, ESCORIALContext co
 .WithName("getProductos")
 .WithOpenApi();
 
-app.MapGet("api/cocinas", async (int? numero, ESCORIALContext context) =>
-{
-    var query = context.etiquetas_maestro_cocinas.AsQueryable();
-    if (numero.HasValue)
-        query = query.Where(c => c.numero == numero.Value);
-    var cocinas = await query
-        .ToListAsync();
-    var productos = new List<Product>();
-    foreach (var cocina in cocinas)
-    {
-        var producto = await context.producto
-            .FirstOrDefaultAsync(producto => producto.codigo == cocina.idproducto);
-        if (producto is not null)
-            productos.Add(new Product
-            {
-                serial = cocina.numero,
-                productId = producto.id,
-                productCode = producto.codigo,
-                description = producto.descripcion,
-                type = "COCINA",
-                maxCantByPallet = 8,
-                isAvailable = await Fun.IsAvailableAsync(cocina.numero, context)
-            });
-    }
-    if (numero.HasValue && productos.Count < 1)
-        return Results.NotFound();
-    return productos.Count == 1 ? Results.Ok(productos.FirstOrDefault()) : Results.Ok(productos);
-})
-.WithName("getCocinas")
-.WithOpenApi();
-
-app.MapGet("api/termos", async (int? numero, ESCORIALContext context) =>
-{
-    var query = context.etiquetas_maestro_termotanques.AsQueryable();
-    if (numero.HasValue)
-        query = query.Where(c => c.numero == numero.Value);
-    var termos = await query
-        .ToListAsync();
-    var productos = new List<Product>();
-    foreach (var termo in termos)
-    {
-        var producto = await context.producto
-            .FirstOrDefaultAsync(producto => producto.codigo == termo.idproducto);
-        if (producto is not null)
-            productos.Add(new Product
-            {
-                serial = termo.numero,
-                productId = producto.id,
-                productCode = producto.codigo,
-                description = producto.descripcion,
-                type = "TERMOTANQUE",
-                maxCantByPallet = 12,
-                isAvailable = await Fun.IsAvailableAsync(termo.numero, context)
-            });
-    }
-    if (numero.HasValue && productos.Count < 1)
-        return Results.NotFound();
-    return productos.Count == 1 ? Results.Ok(productos.FirstOrDefault()) : Results.Ok(productos);
-})
-.WithName("getTermos")
-.WithOpenApi();
-
 app.MapPost("api/pallets/asociar-productos", async (cenker_pallets pallet, ESCORIALContext context) =>
 {
     await using var transaction = await context.Database.BeginTransactionAsync();


### PR DESCRIPTION
#### PR Classification  
API change and code cleanup.  

#### PR Summary  
This PR introduces a configuration for the `dotnet-ef` tool, enhances an existing API endpoint, and removes two deprecated endpoints.  
- Added `dotnet-tools.json` to configure `dotnet-ef` (version `9.0.9`).  
- Updated `Program.cs`: Enhanced `api/pallets/productos` to dynamically calculate `maxCantByPallet` using `ud_producto`.  
- Removed `api/cocinas` and `api/termos` endpoints from `Program.cs`.  
